### PR TITLE
Demo page: update text and add expand-button animation

### DIFF
--- a/src/assets/styles/home.scss
+++ b/src/assets/styles/home.scss
@@ -89,14 +89,14 @@ body.dark-theme .four-third {
   font-size: 0.75em;
   animation-name: anim-slide-right;
   animation-timing-function: linear;
-  animation-delay: 5s;
+  animation-delay: 10s;
   animation-duration: 10s;
 }
 
 .button-shake {
   animation-name: anim-button-shake;
   animation-timing-function: linear;
-  animation-delay: 7s;
+  animation-delay: 12s;
   animation-duration: 0.5s;
-  animation-iteration-count: ;
+  animation-iteration-count: 2;
 }

--- a/src/assets/styles/home.scss
+++ b/src/assets/styles/home.scss
@@ -42,3 +42,61 @@
 body.dark-theme .four-third {
   border: 1px solid transparentize($white, 0.95);
 }
+
+
+@keyframes anim-button-shake {
+  10%, 90% {
+    transform: translate(-1px, 0);
+  }
+
+  20%, 80% {
+    transform: translate(2px, 0);
+  }
+
+  30%, 50%, 70% {
+    transform: translate(-4px, 0);
+  }
+
+  40%, 60% {
+    transform: translate(4px, 0);
+  }
+
+  100% {
+    transform: translate(0, 0);
+  }
+}
+
+@keyframes anim-slide-right {
+  0% {
+    visibility: visible;
+    margin-left: -100%;
+  }
+  10%, 90%{
+    margin-left: 0%;
+  }
+  100% {
+    margin-left: -100%;
+  }
+}
+
+.slide-right {
+  overflow: hidden;
+}
+
+.slide-right span {
+  visibility: hidden;
+  display: inline-block;
+  font-size: 0.75em;
+  animation-name: anim-slide-right;
+  animation-timing-function: linear;
+  animation-delay: 5s;
+  animation-duration: 10s;
+}
+
+.button-shake {
+  animation-name: anim-button-shake;
+  animation-timing-function: linear;
+  animation-delay: 7s;
+  animation-duration: 0.5s;
+  animation-iteration-count: ;
+}

--- a/src/demo.html
+++ b/src/demo.html
@@ -64,7 +64,7 @@
         </a>
         <a
           href="app/"
-          class="btn is-uppercased icon-only"
+          class="btn is-uppercased icon-only button-shake"
           title="Launch HiGlass in Full Screen">
           <svg class="icon">
             <use
@@ -72,6 +72,9 @@
               xlink:href="../assets/images/icons.svg#maximize"></use>
           </svg>
         </a>
+        <div class="slide-right">
+          <span>Click to launch in full screen!</span>
+        </div>
       </div>
       <nav class="flex-c flex-jc-e flex-a-s is-toggable">
         <ul class="flex-c flex-jc-e flex-a-s no-list-style">
@@ -113,34 +116,33 @@
     <div class="wrap">
       <section class="flex-c m-t-1 m-b-1">
 
-        <p class="intro flex-i-g-1">
+      <p class="intro flex-i-g-1">
         HiGlass is a tool for exploring genomic contact matrices and tracks.
         Please take a look at the <a href="examples">examples</a> and <a
         href="https://docs.higlass.io">documentation</a> for a
-    description of the ways that it can be configured to explore and compare
-    contact matrices. To load private data, HiGlass can be <a
-    href="https://docs.higlass.io/atutorial.html">run locally
-within a Docker container</a>. The HiC data in the examples below is from Rao
-et al. (2014) <a href="#references">[2]</a>.
+        description of the ways that it can be configured to explore and compare
+        contact matrices. To load private data, HiGlass can be <a
+        href="https://docs.higlass.io/atutorial.html">run locally
+        within a Docker container</a>. The HiC data in the examples below is from Rao
+        et al. (2014) <a href="#references">[2]</a>.
 
         <br />
         <br />
 
         A preprint of the paper describing HiGlass is <a href="https://doi.org/10.1101/121889">available on bioRxiv</a> <a href="#references">[1]</a>.
-
-        </p>
+      </p>
 
       </section>
       <p class="m-b-1">
-        <b> Single View </b>
+        <b>Single View</b>
       </p>
       <div class="four-third m-b-1">
         <div id="higlass1" class="full-dim"></div>
       </div>
-      <p class="m-b-1">
-        <b> Two Linked Views </b>
-      </p>
 
+      <p class="m-b-1">
+        <b>Two Linked Views</b>
+      </p>
       <p class="m-b-1">
         HiGlass can also be configured to show two or more views. These views can be synchronized to always show the same
         location. For more information, please see the documentation about <a href="https://docs.higlass.io/b_viewer.html#replacing-tracks">replacing tracks</a>, <a href="https://docs.higlass.io/b_viewer.html#adding-views">adding new views</a>, and <a href="https://github.com/hms-dbmi/higlass/wiki/View-Operations#view-synchronization">synchronizing the locations of different views</a>.
@@ -150,54 +152,44 @@ et al. (2014) <a href="#references">[2]</a>.
       </div>
 
       <p class="m-b-1">
-        <b> Genome browser-like view</b>
+        <b>Classic Genome Browser Layout</b>
       </p>
+      <p class="m-b-1">
+        If the 2D view is omitted, HiGlass functions like a regular 1D
+        genome browser. See the documentation for more information about
+        the <a href="https://docs.higlass.io/track_types.html"> different available track types</a> and how to
+        <a href="https://github.com/hms-dbmi/higlass/wiki/Common-Tasks#adding-a-new-tracks"> add them</a>. 
+        Blue gene annotations are on the + strand while red annotations are on the - strand. This view shows a gene annotations track
+        as well as four ENCODE data tracks containing ChIP seq profiles (H3K27ac, H3K4me1, H3K4me and H3K27me3).
+      </p>
+      <div id="higlass3" ></div>
 
       <p class="m-b-1">
-
-            If the 2D view is omitted, HiGlass functions much like a regular
-            genome browser. See the documentation for more information about
-                the <a
-         href="https://docs.higlass.io/track_types.html"> different
-         available track types</a> and how to   <a
-         href="https://github.com/hms-dbmi/higlass/wiki/Common-Tasks#adding-a-new-tracks">
-         add them</a>. Blue gene annotations are on the + strand while red
-     annotations are on the - strand. This view shows a gene annotations track
-     as well as four ENCODE data tracks containing ChIP seq profiles (H3K27ac,
-     H3K4me1, H3K4me and H3K27me3).
-
+        <b>Genome Browser Layout With Detail Views</b>
       </p>
-        <div id="higlass3" ></div>
-
-      <p class="m-b-1">
-        <b> Genome browser-like view with details</b>
-      </p>
-
-      <p class="m-b-1">
-            
+      <p class="m-b-1">  
         All of the inter-view operations, such as linking and viewport projection are also available
-        in the simplified genome browser-like view. The example below shows a zoomed-out overview on
+        in the simplified genome browser layout. The example below shows a zoomed-out overview on
         top as well as two detail views below. The positions of the detail views are shown on the overview
         using <a href="https://github.com/hms-dbmi/higlass/wiki/Viewport-projection">viewport projections</a>.
         Blue gene annotations are on the + strand while red annotations are on the - strand. The data is
         from Busslinger et al (2017) <a href="#references">[3]</a> and shows the accumulation of cohesin at sites of convergent
         transcription in CTCF / Wapl double knock-out mouse embryonic fibroblasts.
-
       </p>
-        <div id="higlass4" ></div>
-      
-        <p>
+      <div id="higlass4" ></div>
+
+      <p>
         <b><a name="references">References</a></b>
-        </p>
-        <p>
-        [1] Kerpedjiev, Peter, et al. "HiGlass: Web-based visual comparison and exploration of genome interaction maps." bioRxiv (2017): 121889.
-        </p>
-        <p>
-        [2] Rao, Suhas SP, et al. "A 3D map of the human genome at kilobase resolution reveals principles of chromatin looping." <i>Cell</i> 159.7 (2014): 1665-1680.
-        </p>
-        <p>
-        [3] Busslinger, Georg A., et al. "Cohesin is positioned in mammalian genomes by transcription, CTCF and Wapl." <i>Nature</i> 544.7651 (2017): 503-507.
-        </p>
+      </p>
+      <p>
+      [1] Kerpedjiev, Peter, et al. "HiGlass: Web-based visual comparison and exploration of genome interaction maps." bioRxiv (2017): 121889.
+      </p>
+      <p>
+      [2] Rao, Suhas SP, et al. "A 3D map of the human genome at kilobase resolution reveals principles of chromatin looping." <i>Cell</i> 159.7 (2014): 1665-1680.
+      </p>
+      <p>
+      [3] Busslinger, Georg A., et al. "Cohesin is positioned in mammalian genomes by transcription, CTCF and Wapl." <i>Nature</i> 544.7651 (2017): 503-507.
+      </p>
     </div>
   </main>
 


### PR DESCRIPTION
This is to help make users aware of the expand button in the header. After a delay, some markee text saying "Click to launch in full screen" scrolls out to the right of the expand button, the button shakes, then the text recedes. Doesn't always play well with page load latency, though.

There are also some small changes to the text.